### PR TITLE
Required modules load fixed

### DIFF
--- a/Shared/A2v10.Request/VueDataScripter.cs
+++ b/Shared/A2v10.Request/VueDataScripter.cs
@@ -328,8 +328,6 @@ const vm = new DataModelController({
 			return sb.ToString();
 		}
 
-		HashSet<String> _modulesWritten;
-
 		void AddRequiredModules(StringBuilder sb, String clientScript)
 		{
 			const String tmlHeader =
@@ -347,8 +345,7 @@ const vm = new DataModelController({
 
 			if (String.IsNullOrEmpty(clientScript))
 				return;
-			if (_modulesWritten == null)
-				_modulesWritten = new HashSet<String>();
+            var _modulesWritten = new HashSet<String>();
 			Int32 iIndex = 0;
 			while (true)
 			{


### PR DESCRIPTION
Modules, which are already written was stored in class field _modulesWritten, stored for class instance. So every next call of AddRequiredModules was skipping modules, written by the previous call.
I made _modulesWritten local variable in AddRequiredModules, so written modules list now filled for every call independently.